### PR TITLE
haproxy: introduce http-edge. Generate redirects-in-map-files from a matrix of domains/envs

### DIFF
--- a/manifests/haproxy/autoload.pp
+++ b/manifests/haproxy/autoload.pp
@@ -10,10 +10,59 @@ class ducktape::haproxy::autoload (
   Boolean $userlist           = true,
   Hash    $userlist_defaults  = {},
   Hash    $userlists          = {},
+  Boolean $http_edge                = true,
+  String  $http_edge_path           = '/opt/http-edge',
+  String  $http_edge_path_owner     = 'root',
+  String  $http_edge_frontend       = 'default_fe',
+  Array   $http_edge_redirect_types = [ 'str', 'beg', 'end', 'sub', 'dir', 'regm' ],
+  Hash    $http_edge_domains_envs   = {},
 ) {
 
   if $frontend {
-    create_resources('haproxy::frontend', $frontends, $frontend_defaults)
+    if $http_edge {
+      file { $http_edge_path:
+        ensure => directory,
+        owner => $http_edge_path_owner,
+        mode => "2755",
+      }
+
+      $rules = $http_edge_domains_envs.map |$domain, $options| {
+        $options['_envs'].map |$env| {
+          $path_env = "${http_edge_path}/${env}"
+          if $options[$env] {
+            $domain_env = $options[$env]
+          }
+          else {
+            $parts = [$options['_domain_prefix'], $env, $options['_domain_suffix']].filter |$item| { !$item.empty }
+            $domain_env = join($parts, '.')
+          }
+          file { [$path_env,
+            "$path_env/current",
+            "$path_env/current/redirects"]:
+            ensure => directory,
+            owner => $http_edge_path_owner,
+            replace => false
+          }
+          $http_edge_redirect_types.map |$type| {
+            $map_file = "$path_env/current/redirects/$domain.$type.map"
+            $map_func = "map_$type"
+            file { $map_file:
+              ensure => present,
+              owner => $http_edge_path_owner,
+            }
+            "redirect location %[path,$map_func($map_file)] code 301 if { hdr(host) -i $domain_env } { path,$map_func($map_file) -m found } !{ path,$map_func($map_file) -m str haproxy-skip }"
+          }
+        }
+      }
+
+      $http_request_rules = {$http_edge_frontend => {'options' => {'http-request' => concat($frontends[$http_edge_frontend]['options']['http-request'], flatten($rules))}}}
+      $frontends_real = deep_merge($frontends, $http_request_rules)
+    }
+    else {
+      $frontends_real = $frontends
+    }
+
+    create_resources('haproxy::frontend', $frontends_real, $frontend_defaults)
   }
 
   if $backend {
@@ -34,4 +83,3 @@ class ducktape::haproxy::autoload (
     create_resources('haproxy::userlist', $userlists, $userlist_defaults)
   }
 }
-


### PR DESCRIPTION
Example hiera code:

```
---

ducktape::haproxy::autoload::http_edge_domains_envs:
  example.com:
    _envs:
      - 'stg'
    _domain_prefix: ''
    _domain_suffix: 'd8.example.com'
    pro: 'www.example.com'
```


Resulting haproxy rules:

```
http-request redirect location %[path,map_str(/opt/http-edge/stg/current/redirects/example.com.str.map)] code 301 if { hdr(host) -i www.example.com } { path,map_str(/opt/http-edge/stg/current/redirects/example.com.str.map) -m found } !{ path,map_str(/opt/http-edge/stg/current/redirects/example.com.str.map) -m str haproxy-skip }
http-request redirect location %[path,map_beg(/opt/http-edge/stg/current/redirects/example.com.beg.map)] code 301 if { hdr(host) -i www.example.com } { path,map_beg(/opt/http-edge/stg/current/redirects/example.com.beg.map) -m found } !{ path,map_beg(/opt/http-edge/stg/current/redirects/example.com.beg.map) -m str haproxy-skip }
http-request redirect location %[path,map_end(/opt/http-edge/stg/current/redirects/example.com.end.map)] code 301 if { hdr(host) -i www.example.com } { path,map_end(/opt/http-edge/stg/current/redirects/example.com.end.map) -m found } !{ path,map_end(/opt/http-edge/stg/current/redirects/example.com.end.map) -m str haproxy-skip }
http-request redirect location %[path,map_sub(/opt/http-edge/stg/current/redirects/example.com.sub.map)] code 301 if { hdr(host) -i www.example.com } { path,map_sub(/opt/http-edge/stg/current/redirects/example.com.sub.map) -m found } !{ path,map_sub(/opt/http-edge/stg/current/redirects/example.com.sub.map) -m str haproxy-skip }
http-request redirect location %[path,map_dir(/opt/http-edge/stg/current/redirects/example.com.dir.map)] code 301 if { hdr(host) -i www.example.com } { path,map_dir(/opt/http-edge/stg/current/redirects/example.com.dir.map) -m found } !{ path,map_dir(/opt/http-edge/stg/current/redirects/example.com.dir.map) -m str haproxy-skip }
http-request redirect location %[path,map_regm(/opt/http-edge/stg/current/redirects/example.com.regm.map)] code 301 if { hdr(host) -i www.example.com } { path,map_regm(/opt/http-edge/stg/current/redirects/example.com.regm.map) -m found } !{ path,map_regm(/opt/http-edge/stg/current/redirects/example.com.regm.map) -m str haproxy-skip }


http-request redirect location %[path,map_str(/opt/http-edge/stg/current/redirects/example.com.str.map)] code 301 if { hdr(host) -i stg.d8.example.com } { path,map_str(/opt/http-edge/stg/current/redirects/example.com.str.map) -m found } !{ path,map_str(/opt/http-edge/stg/current/redirects/example.com.str.map) -m str haproxy-skip }
http-request redirect location %[path,map_beg(/opt/http-edge/stg/current/redirects/example.com.beg.map)] code 301 if { hdr(host) -i stg.d8.example.com } { path,map_beg(/opt/http-edge/stg/current/redirects/example.com.beg.map) -m found } !{ path,map_beg(/opt/http-edge/stg/current/redirects/example.com.beg.map) -m str haproxy-skip }
http-request redirect location %[path,map_end(/opt/http-edge/stg/current/redirects/example.com.end.map)] code 301 if { hdr(host) -i stg.d8.example.com } { path,map_end(/opt/http-edge/stg/current/redirects/example.com.end.map) -m found } !{ path,map_end(/opt/http-edge/stg/current/redirects/example.com.end.map) -m str haproxy-skip }
http-request redirect location %[path,map_sub(/opt/http-edge/stg/current/redirects/example.com.sub.map)] code 301 if { hdr(host) -i stg.d8.example.com } { path,map_sub(/opt/http-edge/stg/current/redirects/example.com.sub.map) -m found } !{ path,map_sub(/opt/http-edge/stg/current/redirects/example.com.sub.map) -m str haproxy-skip }
http-request redirect location %[path,map_dir(/opt/http-edge/stg/current/redirects/example.com.dir.map)] code 301 if { hdr(host) -i stg.d8.example.com } { path,map_dir(/opt/http-edge/stg/current/redirects/example.com.dir.map) -m found } !{ path,map_dir(/opt/http-edge/stg/current/redirects/example.com.dir.map) -m str haproxy-skip }
http-request redirect location %[path,map_regm(/opt/http-edge/stg/current/redirects/example.com.regm.map)] code 301 if { hdr(host) -i stg.d8.example.com } { path,map_regm(/opt/http-edge/stg/current/redirects/example.com.regm.map) -m found } !{ path,map_regm(/opt/http-edge/stg/current/redirects/example.com.regm.map) -m str haproxy-skip }
```


Also creates this layout in the filesystem:

```
/opt/http-edge/pro/
/opt/http-edge/pro/current
/opt/http-edge/pro/current/redirects
/opt/http-edge/pro/current/redirects/example.com.dir.map
/opt/http-edge/pro/current/redirects/example.com.end.map
/opt/http-edge/pro/current/redirects/example.com.sub.map
/opt/http-edge/pro/current/redirects/example.com.beg.map
/opt/http-edge/pro/current/redirects/example.com.regm.map
/opt/http-edge/pro/current/redirects/example.com.str.map
/opt/http-edge/stg/
/opt/http-edge/stg/current
/opt/http-edge/stg/current/redirects
/opt/http-edge/stg/current/redirects/example.com.dir.map
/opt/http-edge/stg/current/redirects/example.com.end.map
/opt/http-edge/stg/current/redirects/example.com.sub.map
/opt/http-edge/stg/current/redirects/example.com.beg.map
/opt/http-edge/stg/current/redirects/example.com.regm.map
/opt/http-edge/stg/current/redirects/example.com.str.map
```
